### PR TITLE
Use PUT request for set* calls, added create* calls for POST requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Currently the API provides access just read-only access to Pingdom's API. In cas
 
 * [rwky](https://github.com/rwky) - Handling of irregular parts of the API
 * [Kevin Moritz](https://github.com/ecorkevin) - Massive improvements (promise-based API, basic tests, cleanup)
+* [Leonhardt Wille](https://github.com/lwille) - PUT for update calls
 
 ## License
 

--- a/lib/pingdom.js
+++ b/lib/pingdom.js
@@ -48,10 +48,15 @@ function init(config) {
   });
 
   var setApi = setResources.map(function(setResource) {
-    return ['set' + capitalizeFirstLetterAndRemovePeriod(setResource), template.bind(undefined, config, baseUrl, setResource, 'post')];
+    return ['set' + capitalizeFirstLetterAndRemovePeriod(setResource), template.bind(undefined, config, baseUrl, setResource, 'put')];
   });
 
-  return annozip.toObject(legacyApi.concat(getApi).concat(setApi));
+  var createApi = setResources.map(function(setResource) {
+    return ['create' + capitalizeFirstLetterAndRemovePeriod(setResource), template.bind(undefined, config, baseUrl, setResource, 'post')];
+  });
+
+
+  return annozip.toObject(legacyApi.concat(getApi).concat(setApi).concat(createApi));
 
 }
 module.exports = init;


### PR DESCRIPTION
using `setChecks` to modify existing checks is failing because `POST` is used instead of `PUT`.

This merge request changes the method for `set*` calls to `PUT` and adds `create*` calls to use `POST` method.