### PR TITLE
If the response is only a message, return the message object

### DIFF
--- a/lib/pingdom.js
+++ b/lib/pingdom.js
@@ -127,7 +127,14 @@ function template(config, baseUrl, property, method, options, cb) {
       }
 
       if (typeof resourcesToKey[property] !== 'undefined') {
-        data = resourcesToKey[property](obj);
+        // if the response is simply a message, return it
+        // https://www.pingdom.com/resources/api#MethodModify+Check
+        if (obj.message && Object.keys(obj).length === 1) {
+          data = obj;
+        }
+        else {
+          data = resourcesToKey[property](obj);
+        }        
       } else {
         data = JSON.parse(res.body)[property.split('.')[1]] || JSON.parse(res.body)[property.split('.')[0]];
       }


### PR DESCRIPTION
Some methods in the pingdom API (modify check, delete check, etc) will only return an object that looks like
```js
{
  "message":"Deletion of check was successful!"
}
```
Previously I was assuming each method returned a top-level field called "checks", "contacts", etc.  And the response coming back from those methods was `undefined`.  Added a check in to see if the response is only a message, and if so, just return the above object in that case.